### PR TITLE
Add requested features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -364,3 +364,4 @@ FodyWeavers.xsd
 /lib/Assembly-CSharp.dll
 /lib/netstandard.dll
 /lib/AutoSetPrices.dll
+*.dll

--- a/CardSeller.csproj
+++ b/CardSeller.csproj
@@ -36,6 +36,10 @@
       <HintPath>lib\netstandard.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Unity.TextMeshPro, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>lib\Unity.TextMeshPro.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">

--- a/PatchIt.cs
+++ b/PatchIt.cs
@@ -91,6 +91,7 @@ public static class PatchIt
             Plugin.Logger.LogInfo("First index of sorted array MP: " + CPlayerData.GetCardMarketPrice(allMatchingCards[0]));
             Plugin.Logger.LogInfo("Last index of sorted array MP: " + CPlayerData.GetCardMarketPrice(allMatchingCards[allMatchingCards.Count - 1]));
         }
+        Plugin.Logger.LogInfo("Finished finding cards.");
         return allMatchingCards;
     }
 
@@ -102,6 +103,7 @@ public static class PatchIt
         isRunning = true;
 
         List<CardData> allCardsSorted = GetCompatibleCards();
+        Plugin.Logger.LogInfo("Got " + allCardsSorted.Count + " cards to place");
 
         //find all card shelves in the shop
         List<CardShelf> cardShelfList = CSingleton<ShelfManager>.Instance.m_CardShelfList;

--- a/PatchIt.cs
+++ b/PatchIt.cs
@@ -119,7 +119,7 @@ public static class PatchIt
             //find all the compartments in that shelf
             List<InteractableCardCompartment> cardCompartments = shelf.GetCardCompartmentList();
             int maxLoop = cardCompartments.Count;
-            if(maxLoop > allCardsSorted.Count) maxLoop = allCardsSorted.Count;
+            if(maxLoop > totalMatchingCards) maxLoop = totalMatchingCards;
 
             for(int j = 0; j < cardCompartments.Count; j++)
             {

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -21,6 +21,7 @@ public class Plugin : BaseUnityPlugin
     internal static ConfigEntry<float> m_ConfigSellOnlyLessThanMP;
     internal static ConfigEntry<KeyboardShortcut> m_ConfigKeyboardTriggerCardSet;
     internal static ConfigEntry<bool> m_ConfigOnlySellDuplicates;
+    internal static ConfigEntry<bool> m_ConfigShouldShowProgressPopUp;
 
     //filter config settings
     internal static ConfigEntry<bool> m_ConfigShouldSellTetramonCards;
@@ -42,6 +43,7 @@ public class Plugin : BaseUnityPlugin
         m_ConfigSellOnlyLessThanMP = Config.Bind("General", "SellOnlyLessThan", 100.00f, "Ignore cards in the album with a market value above this.");
         m_ConfigKeyboardTriggerCardSet = Config.Bind<KeyboardShortcut>("General", "SetOutCardsKey", new KeyboardShortcut(KeyCode.F9, Array.Empty<KeyCode>()), "Keyboard shortcut to set out cards.");
         m_ConfigOnlySellDuplicates = Config.Bind("General", "SellOnlyDuplicates", false, "Ignore cards in the album with a quantity of 1");
+        m_ConfigShouldShowProgressPopUp = Config.Bind("General", "ShowPopUpForNumCardsSet", false, "When the mod is triggered, show text on-screen with information about how many cards match the filter(s) and how many were placed. Note: not recommended in conjunction with the 'ShouldTriggerOnCardPickup' option.");
 
         //filter config init
         m_ConfigShouldSellTetramonCards = Config.Bind("Filters", "ShouldSellTetramonCards", true, "Do you want to sell your Tetramon set cards?");

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -22,6 +22,12 @@ public class Plugin : BaseUnityPlugin
     internal static ConfigEntry<KeyboardShortcut> m_ConfigKeyboardTriggerCardSet;
     internal static ConfigEntry<bool> m_ConfigOnlySellDuplicates;
 
+    //filter config settings
+    internal static ConfigEntry<bool> m_ConfigShouldSellTetramonCards;
+    internal static ConfigEntry<bool> m_ConfigShouldSellDestinyCards;
+    internal static ConfigEntry<bool> m_ConfigShouldSellGhostCards;
+    internal static ConfigEntry<bool> m_ConfigShouldSellDestinyGhostCards;
+
     //trigger config settings
     internal static ConfigEntry<bool> m_ConfigShouldTriggerOnCustomerCardPickup;
     internal static ConfigEntry<bool> m_ConfigShouldTriggerOnDayStart;
@@ -36,6 +42,12 @@ public class Plugin : BaseUnityPlugin
         m_ConfigSellOnlyLessThanMP = Config.Bind("General", "SellOnlyLessThan", 100.00f, "Ignore cards in the album with a market value above this.");
         m_ConfigKeyboardTriggerCardSet = Config.Bind<KeyboardShortcut>("General", "SetOutCardsKey", new KeyboardShortcut(KeyCode.F9, Array.Empty<KeyCode>()), "Keyboard shortcut to set out cards.");
         m_ConfigOnlySellDuplicates = Config.Bind("General", "SellOnlyDuplicates", false, "Ignore cards in the album with a quantity of 1");
+
+        //filter config init
+        m_ConfigShouldSellTetramonCards = Config.Bind("Filters", "ShouldSellTetramonCards", true, "Do you want to sell your Tetramon set cards?");
+        m_ConfigShouldSellDestinyCards = Config.Bind("Filters", "ShouldSellDestinyCards", true, "Do you want to sell your Destiny set cards?");
+        m_ConfigShouldSellGhostCards = Config.Bind("Filters", "ShouldSellGhostCards", false, "Do you want to sell your white Ghost cards?");
+        m_ConfigShouldSellDestinyGhostCards = Config.Bind("Filters", "ShouldSellDestinyGhostCards", false, "Do you want to sell your dimension (aka black/Destiny) ghost cards?");
 
         //trigger config init
         m_ConfigShouldTriggerOnCustomerCardPickup = Config.Bind("Triggers", "ShouldTriggerOnCardPickup", false, "Do you want your cards to automatically be placed on all empty shelves whenever a customer picks up a card?");

--- a/lib/libs.txt
+++ b/lib/libs.txt
@@ -1,6 +1,7 @@
 Find and add the following .dlls from the game files to this folder:
 Assembly-CSharp.dll
 netstandard.dll
+Unity.TextMeshPro.dll
 
 Download the following mod DLLs and add them to this folder:
 AutoSetPrices.dll


### PR DESCRIPTION
Add support for Destiny and Ghost cards
Add filter config options for Tetramon, Destiny, Ghost, and Dimension(/black/Destiny) Ghost set cards
Reduce potential hitching when many cards are being set out on shelves
Add option to show an on-screen pop-up about how many cards were set out and how many cards match the configured filters